### PR TITLE
Add wait_for_network_idle method to manage network idle state before PDF conversion

### DIFF
--- a/lib/gotenberg/chromium/properties.rb
+++ b/lib/gotenberg/chromium/properties.rb
@@ -87,7 +87,15 @@ module Gotenberg
 
         self
       end
- 
+
+      # Waits for the network to be idle before converting an HTML document to PDF.
+      # https://gotenberg.dev/docs/routes#performance-mode-chromium
+      def wait_for_network_idle
+        properties['skipNetworkIdleEvent'] = false # default is true
+
+        self
+      end
+
       # DEPRECATED in Gotenberg 8. Overrides the default "User-Agent" header.
       def user_agent user_agent
         properties['userAgent'] = user_agent
@@ -108,7 +116,7 @@ module Gotenberg
 
         self
       end
- 
+
       # Forces Chromium to emulate the media type "print" or "screen".
       def emulate_media_type type
         properties['emulatedMediaType'] = type
@@ -140,7 +148,7 @@ module Gotenberg
       end
 
       private
- 
+
       def properties
         @properties ||= {}
       end


### PR DESCRIPTION
Since Gotenberg version [8.11.0](https://github.com/gotenberg/gotenberg/releases/tag/v8.11.0), the default value for `skipNetworkIdleEvent` is set to true.

There are rare cases where waiting for network idle makes sense. This PR enables changing the value to `false`.

Thanks for your work!