### PR TITLE
Fix parsing of html that has multiple context tags in the same file

### DIFF
--- a/lib/gotenberg/compiler.rb
+++ b/lib/gotenberg/compiler.rb
@@ -5,7 +5,7 @@ require 'gotenberg/analyzers/css'
 
 module Gotenberg
   class Compiler
-    CONTEXT_TAG_REGEX = /(<!-- GOTENBERG-CONTEXT-TAG (.+) -->)/.freeze
+    CONTEXT_TAG_REGEX = /(<!-- GOTENBERG-CONTEXT-TAG (.+?) -->)/.freeze
 
     attr_accessor :html
 


### PR DESCRIPTION
If your html has multiple Gotenberg context blocks on the same line, they will all be selected. This can happen when the html is generated by a controller. This change makes it so it will correctly match at the end of the tag.

Ex:
```
<!DOCTYPE html><html><head><meta charset="utf-8" /><link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" media="screen" /><!-- GOTENBERG-CONTEXT-TAG {"absolute_path":true,"skip_analyze":true,"tag":"css","src":"/srv/app/public/packs-test/css/note_pdf-19e3bb2c.css","base_path":"/srv/app"} --><!-- GOTENBERG-CONTEXT-TAG {"absolute_path":true,"skip_analyze":true,"tag":"css","src":"/srv/app/public/packs-test/css/signed_pdf-f14470d3.css","base_path":"/srv/app"} --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" media="screen" /></head><body><div class="header"><table class="header-table"><tbody><tr><td>Note</td><td style="text-align: right;"><!-- GOTENBERG-CONTEXT-TAG {"absolute_path":true,"tag":"image","src":"/srv/app/public/packs-test/static/images/logo-whitebg-x-7c91061449e0ff09dad1.png"} --></td></tr></tbody></table></div><div class="pdf_container"><div class="content"><div class="data"><h3><strong>Title</strong></h3></div><div class="data"><h5><strong>Information</strong></h5><ul><li><strong class="font-11">Date:&nbsp</strong><span>06-11-2026</span></li><li><strong class="font-11">Time:&nbsp</strong><span>08:00 AM CDT</span></li></ul></div><br /><br /><b>---------- Note Timestamps ----------</b><br /><br /><p>06-17-2026 09:51 AM CDT - Lynwood Rob drafted note and submitted it</p></div></div></body></html>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context tag parsing to ensure accurate extraction of configuration values, preventing potential issues with document compilation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->