### PR TITLE
Expose response details on transform errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,21 @@ Gotenberg::TransformError
 Gotenberg::RemoteSourceError
 ```
 
+HTTP response details are available on transform errors:
+
+```ruby
+error = document.exception
+
+error.original_error
+error.response
+error.response_status
+error.response_headers
+error.response_body
+```
+
+The response values are `nil` when the request failed before receiving an HTTP
+response.
+
 You may inject `<link>` and `<script>` HTML elements thanks to the `extra_link_tags` and `extra_script_tags` arguments:
 
 ```ruby

--- a/lib/gotenberg/exceptions.rb
+++ b/lib/gotenberg/exceptions.rb
@@ -1,4 +1,25 @@
 module Gotenberg
-  class TransformError < StandardError; end
+  class TransformError < StandardError
+    RESPONSE_ATTRIBUTES = %i[
+      response
+      response_status
+      response_headers
+      response_body
+    ].freeze
+
+    attr_reader :original_error
+
+    def initialize(original_error = nil)
+      @original_error = original_error
+      super
+    end
+
+    RESPONSE_ATTRIBUTES.each do |attribute|
+      define_method attribute do
+        original_error.public_send(attribute) if original_error.respond_to?(attribute)
+      end
+    end
+  end
+
   class RemoteSourceError < StandardError; end
 end

--- a/test/gotenberg/transform_error_test.rb
+++ b/test/gotenberg/transform_error_test.rb
@@ -1,0 +1,68 @@
+require 'minitest/autorun'
+require 'faraday'
+require 'gotenberg/exceptions'
+
+class TransformErrorTest < Minitest::Test
+  HTTP_RESPONSE = {
+    status: 400,
+    headers: { 'content-type' => 'application/json' },
+    body: '{"message":"invalid input"}'
+  }.freeze
+
+  def test_retains_http_response_details
+    original_error = Faraday::BadRequestError.new(HTTP_RESPONSE)
+
+    error = Gotenberg::TransformError.new(original_error)
+
+    assert_equal original_error.message, error.message
+    assert_same original_error, error.original_error
+    assert_same HTTP_RESPONSE, error.response
+    assert_equal 400, error.response_status
+    assert_equal({ 'content-type' => 'application/json' }, error.response_headers)
+    assert_equal '{"message":"invalid input"}', error.response_body
+  end
+
+  def test_transport_error_has_no_response_details
+    original_error = Faraday::ConnectionFailed.new('connection failed')
+
+    error = Gotenberg::TransformError.new(original_error)
+
+    assert_equal 'connection failed', error.message
+    assert_same original_error, error.original_error
+    assert_nil error.response
+    assert_nil error.response_status
+    assert_nil error.response_headers
+    assert_nil error.response_body
+  end
+
+  def test_string_construction_remains_supported
+    original_error = 'transformation failed'
+
+    error = Gotenberg::TransformError.new(original_error)
+
+    assert_equal 'transformation failed', error.message
+    assert_same original_error, error.original_error
+    assert_nil error.response
+    assert_nil error.response_status
+    assert_nil error.response_headers
+    assert_nil error.response_body
+  end
+
+  def test_zero_argument_construction_and_raising_remain_supported
+    constructed_error = Gotenberg::TransformError.new
+    raised_error = assert_raises(Gotenberg::TransformError) { raise Gotenberg::TransformError }
+
+    [constructed_error, raised_error].each { |error| assert_empty_transform_error(error) }
+  end
+
+  private
+
+  def assert_empty_transform_error(error)
+    assert_equal 'Gotenberg::TransformError', error.message
+    assert_nil error.original_error
+    assert_nil error.response
+    assert_nil error.response_status
+    assert_nil error.response_headers
+    assert_nil error.response_body
+  end
+end


### PR DESCRIPTION
## Summary

Preserve the original exception when it is wrapped in
`Gotenberg::TransformError` and expose the available HTTP response details:

- `response`
- `response_status`
- `response_headers`
- `response_body`

The response accessors return `nil` when the original error does not contain an
HTTP response, such as a connection failure.

Existing message handling, string-based construction, and zero-argument
exception construction remain supported.

The README now includes an example of inspecting response details.

Fixes #16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Transform errors now preserve the original error and expose available HTTP response details, including status, headers, and response body.
  - Added clear behavior for failures that occur before an HTTP response is received.

- **Documentation**
  - Updated Chromium usage documentation with examples of accessing HTTP response details from transform errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->